### PR TITLE
Feature/initialize database with schema file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 
+# 0.17.0
+
+## Changes 
+
+* The reserved migration IDs threshold has been changed from anything below `10000000000000` to anything below
+`00010101000000`.
+* `Initialize-Database` will now include the `schema.ps1` file from the database's migration directory if it exists.
+
+
 # 0.16.0
 
 * Updated `Checkpoint-Migration` function:

--- a/Rivet/Functions/Get-MigrationFile.ps1
+++ b/Rivet/Functions/Get-MigrationFile.ps1
@@ -64,14 +64,21 @@ function Get-MigrationFile
             }
         } | 
         ForEach-Object {
-            if( $_.BaseName -notmatch '^(\d{14})_(.+)' )
+            if( $_.BaseName -eq 'schema' )
+            {
+                $id = $script:schemaMigrationId # midnight on year 1, month 0, day 0.
+                $name = $_.BaseName
+            }
+            elseif( $_.BaseName -notmatch '^(\d{14})_(.+)' )
             {
                 Write-Error ('Migration {0} has invalid name.  Must be of the form `YYYYmmddhhMMss_MigrationName.ps1' -f $_.FullName)
                 return
             }
-        
-            $id = [int64]$matches[1]
-            $name = $matches[2]
+            else
+            {
+                $id = [int64]$matches[1]
+                $name = $matches[2]
+            }
         
             $_ | 
                 Add-Member -MemberType NoteProperty -Name 'MigrationID' -Value $id -PassThru |

--- a/Rivet/Functions/Initialize-Database.ps1
+++ b/Rivet/Functions/Initialize-Database.ps1
@@ -9,13 +9,27 @@ function Initialize-Database
     param(
         [Parameter(Mandatory=$true)]
         [Rivet.Configuration.Configuration]
-        $Configuration
+        $Configuration,
+
+        [Switch] $Pop
     )
 
     Set-StrictMode -Version 'Latest'
+    Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
 
     $who = ('{0}\{1}' -f $env:USERDOMAIN,$env:USERNAME);
-    $migrationsPath = Join-Path -Path $rivetModuleRoot -ChildPath 'Migrations'
+    $migrationPaths = [System.Collections.ArrayList]::new()
+    $rivetMigrationsPath = Join-Path -Path $rivetModuleRoot -ChildPath 'Migrations'
+    $migrationPaths.Add($rivetMigrationsPath) | Out-Null
     Write-Debug -Message ('# {0}.{1}' -f $Connection.DataSource,$Connection.Database)
-    Update-Database -Path $migrationsPath -RivetSchema -Configuration $Configuration
+
+    # Add schema.ps1 file from database's migration directory if it exists
+    $databaseItem = $Configuration.Databases | Where-Object {$_.Name -eq $Connection.Database}
+    $schemaFilePath = Join-Path -Path $databaseItem.MigrationsRoot -ChildPath 'schema.ps1'
+    if( (Test-Path -Path $schemaFilePath) -and -not $Pop)
+    {
+        $migrationPaths.Add($schemaFilePath) | Out-Null
+    }
+
+    Update-Database -Path $migrationPaths -RivetSchema -Configuration $Configuration
 }

--- a/Rivet/Functions/Invoke-Rivet.ps1
+++ b/Rivet/Functions/Invoke-Rivet.ps1
@@ -192,7 +192,7 @@ Found no databases to migrate. This can be a few things:
         
             try
             {
-                Initialize-Database -Configuration $settings
+                Initialize-Database -Configuration $settings -Pop:$Pop
 
                 $updateParams = @{
                                     Path = $dbMigrationsPath;

--- a/Rivet/Functions/New-Migration.ps1
+++ b/Rivet/Functions/New-Migration.ps1
@@ -20,6 +20,9 @@ function New-Migration
         $Path
     )
 
+    Set-StrictMode -Version 'Latest'
+    Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+
     foreach( $nameItem in $Name )
     {
         $id = $null
@@ -37,6 +40,15 @@ function New-Migration
         $migrationPath = Join-Path -Path $Path -ChildPath $filename
         $migrationPath = [IO.Path]::GetFullPath( $migrationPath )
         New-Item -Path $migrationPath -Force -ItemType File
+
+        $schemaPs1Path = Join-Path -Path $Path -ChildPath $script:schemaMigrationId
+        if (-not (Test-Path -Path $schemaPs1Path))
+        {
+            $script:schemaPreamble | Set-Content -Path $schemaPs1Path
+            $msg = "Rivet created ""$($schemaPs1Path | Resolve-Path -Relative)"", a file where Rivet to stores a " +
+                   'database''s baseline schema. PLEASE CHECK THIS FILE INTO SOURCE CONTROL.'
+            Write-Warning $msg
+        }
 
         $template = @"
 <#

--- a/Rivet/Functions/Update-Database.ps1
+++ b/Rivet/Functions/Update-Database.ps1
@@ -66,6 +66,7 @@ function Update-Database
     )
 
     Set-StrictMode -Version 'Latest'
+    Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
 
     function ConvertTo-RelativeTime
     {
@@ -147,9 +148,9 @@ function Update-Database
                 return $true
             }
 
-            if( [int64]$_.MigrationID -lt 1000000000000 )
+            if( [int64]$_.MigrationID -lt $script:firstMigrationId )
             {
-                Write-Error ('Migration "{0}" has an invalid ID. IDs lower than 01000000000000 are reserved for internal use.' -f $_.FullName) -ErrorAction Stop
+                Write-Error "Migration ""$($_.FullName)"" has an invalid ID. IDs lower than $($script:firstMigrationId) are reserved for internal use." -ErrorAction Stop
                 return $false
             }
             return $true

--- a/Rivet/Rivet.psd1
+++ b/Rivet/Rivet.psd1
@@ -11,7 +11,7 @@
     RootModule = 'Rivet.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.16.0'
+    ModuleVersion = '0.17.0'
 
     # ID used to uniquely identify this module
     GUID = '8af34b47-259b-4630-a945-75d38c33b94d'

--- a/Rivet/Rivet.psm1
+++ b/Rivet/Rivet.psm1
@@ -6,7 +6,22 @@ $RivetMigrationsTableName = 'Migrations'
 $RivetMigrationsTableFullName = "[$($RivetSchemaName)].[$($RivetMigrationsTableName)]"
 $RivetActivityTableName = 'Activity'
 $rivetModuleRoot = $PSScriptRoot
-[Int64] $script:firstMigrationId = 00010101000000
+$script:firstMigrationId = [Int64]'00010101000000' # 1/1/1 00:00:00
+$script:schemaMigrationId = [Int64]'00010000000000' # Special ID for schema.ps1, 1/0/0 00:00:00.
+$script:schemaFileName = 'schema.ps1'
+$script:schemaPreamble = @"
+# DO NOT MODIFY THIS FILE. The current database schema is saved to this file as a Rivet migration when you checkpoint
+# your database. Any changes manually made to this file will eventually be lost. This file should be checked into source
+# control alongside normal database migrations.
+
+function Push-Migration
+{
+}
+
+function Pop-Migration
+{
+}
+"@
 
 $timer = New-Object 'Diagnostics.Stopwatch'
 $timerForWrites = New-Object 'Diagnostics.Stopwatch'

--- a/Test/Checkpoint-Migration.Tests.ps1
+++ b/Test/Checkpoint-Migration.Tests.ps1
@@ -35,6 +35,25 @@ function GivenMigrationContent
     }
 }
 
+function Reset
+{
+    param(
+        [String[]] $Database
+    )
+
+    if( -not $Database )
+    {
+        $Database = $RTDatabaseName
+    }
+
+    foreach( $databaseItem in $Database )
+    {
+        Remove-RivetTestDatabase -Name $databaseItem
+    }
+
+    Stop-RivetTest -DatabaseName $Database
+}
+
 function ThenFailed
 {
     param(
@@ -82,6 +101,26 @@ function ThenMigration
     }
 }
 
+function ThenSchemaFileRunnable
+{
+    foreach( $path in $script:migrationPaths )
+    {
+        $databaseName = $path.Directory.Parent.Name
+        $schemaFilePath = Join-Path -Path (Split-Path $path) -ChildPath 'schema.ps1'
+        $schemaFileContents = Get-Content -Path $schemaFilePath
+        $checkpointedMigration = @{
+            Database = $databaseName;
+            Migration = $schemaFileContents
+        }
+        $script:checkpointedMigrations.Add($checkpointedMigration)
+        It ('should export a runnable migration') {
+            # Now, check that the migration is runnable
+            Remove-RivetTestDatabase -Name $databaseName
+            Invoke-RTRivet -Push -Database $databaseName -ErrorAction Stop
+        }
+    }
+}
+
 function WhenCheckpointingMigration
 {
     [CmdletBinding()]
@@ -95,56 +134,29 @@ function WhenCheckpointingMigration
         [String[]] $Exclude
     )
 
-    try
+    if(-not $Database )
     {
-        if(-not $Database )
-        {
-            $Database = $RTDatabaseName
-        }
+        $Database = $RTDatabaseName
+    }
 
-        if( $ExistingSchemaFile )
-        {
-            foreach( $path in $script:migrationPaths )
-            {
-                New-Item -Path (Split-Path -Path $path) -Name 'schema.ps1' -ItemType 'File'
-            }
-        }
-
-        Invoke-RTRivet -Checkpoint -Database $Database -Force:$Force
-
-        foreach( $migration in $Exclude )
-        {
-            $migrationPathToRemove = $script:migrationPaths | Where-Object {$_ -like $migration}
-            if( $migrationPathToRemove )
-            {
-                $script:migrationPaths.Remove($migrationPathToRemove)
-            }
-        }
-
+    if( $ExistingSchemaFile )
+    {
         foreach( $path in $script:migrationPaths )
         {
-            $databaseName = $path.Directory.Parent.Name
-            $schemaFilePath = Join-Path -Path (Split-Path $path) -ChildPath 'schema.ps1'
-            $schemaFileContents = Get-Content -Path $schemaFilePath
-            $checkpointedMigration = @{
-                Database = $path.Directory.Parent.Name;
-                Migration = $schemaFileContents
-            }
-            $script:checkpointedMigrations.Add($checkpointedMigration)
-            It ('should export a runnable migration') {
-                # Now, check that the migration is runnable
-                Invoke-RTRivet -Pop -Database $databaseName
-
-                $checkpointedMigration.Migration | Set-Content -Path $path
-                Invoke-RTRivet -Push -Database $databaseName -ErrorAction Stop
-                Invoke-RTRivet -Pop -Force -Database $databaseName -ErrorAction Stop
-            }
+            New-Item -Path (Split-Path -Path $path) -Name 'schema.ps1' -ItemType 'File'
         }
     }
-    finally
+
+    foreach( $migration in $Exclude )
     {
-        Stop-RivetTest -DatabaseName $Database
+        $migrationPathToRemove = $script:migrationPaths | Where-Object {$_ -like $migration}
+        if( $migrationPathToRemove )
+        {
+            $script:migrationPaths.Remove($migrationPathToRemove)
+        }
     }
+
+    Invoke-RTRivet -Checkpoint -Database $Database -Force:$Force
 }
 
 Describe 'Checkpoint-Migration.when there are multiple databases' {
@@ -168,6 +180,7 @@ function Pop-Migration
 '@ -Database ('RivetTest', 'RivetTest2')
     Invoke-RTRivet -Push -Database ('RivetTest', 'RivetTest2')
     WhenCheckpointingMigration -Database ('RivetTest', 'RivetTest2')
+    ThenSchemaFileRunnable
     ThenMigration -HasContent @'
     Add-Table -Name 'Replicated' -Column {
         int 'ID' -Identity
@@ -179,6 +192,7 @@ function Pop-Migration
     }
 '@ -Database ('RivetTest', 'RivetTest2')
     ThenNoErrors
+    Reset -Database ('RivetTest', 'RivetTest2')
 }
 
 Describe 'Checkpoint-Migration.when schema.ps1 file already exists' {
@@ -199,6 +213,7 @@ function Pop-Migration
     Invoke-RTRivet -Push -Database $RTDatabaseName
     WhenCheckpointingMigration -ExistingSchemaFile -ErrorAction SilentlyContinue
     ThenFailed -WithError 'schema.ps1" already exists.'
+    Reset
 }
 
 Describe 'Checkpoint-Migration.when schema.ps1 file already exists but -Force switch is given' {
@@ -218,12 +233,14 @@ function Pop-Migration
 '@
     Invoke-RTRivet -Push -Database $RTDatabaseName
     WhenCheckpointingMigration -ExistingSchemaFile -Force
+    ThenSchemaFileRunnable
     ThenMigration -HasContent @'
     Add-Table -Name 'NotReplicated' -Column {
         int 'ID' -Identity -NotForReplication
     }
 '@ -Database $RTDatabaseName
     ThenNoErrors
+    Reset
 }
 
 Describe 'Checkpoint-Migration.when checkpointing a migration' {
@@ -281,6 +298,7 @@ function Pop-Migration
 '@
     Invoke-RTRivet -Push -Database $RTDatabaseName
     WhenCheckpointingMigration
+    ThenSchemaFileRunnable
     ThenMigration -Not -HasContent 'Add-Schema -Name ''dbo''' -Database $RTDatabaseName
     ThenMigration -HasContent @'
     Add-Table -Name 'Migrations' -Description 'some table''s description' -Column {
@@ -341,6 +359,7 @@ ON [dbo].[Migrations] for insert as select 1
     ThenMigration -Not -HasContent 'Remove-UniqueKey' -Database $RTDatabaseName
     ThenMigration -Not -HasContent 'Remove-Trigger' -Database $RTDatabaseName
     ThenNoErrors
+    Reset
 }
 
 Describe 'Checkpoint-Migration.when there are multiple migrations but only one has been pushed' {
@@ -373,6 +392,7 @@ function Pop-Migration
 }
 '@
     WhenCheckpointingMigration -Exclude $script:migrationPaths[1]
+    ThenSchemaFileRunnable
     ThenMigration -HasContent @'
     Add-Table -Name 'Test1' -Column {
         int 'ID' -Identity
@@ -384,10 +404,13 @@ function Pop-Migration
     }
 '@ -Database $RTDatabaseName
     ThenNoErrors
+    Reset
 }
 
 Describe 'Checkpoint-Migration.when no migrations have been pushed' {
     Init
     WhenCheckpointingMigration
+    ThenSchemaFileRunnable
     ThenNoErrors
+    Reset
 }

--- a/Test/Initialize-Database.Tests.ps1
+++ b/Test/Initialize-Database.Tests.ps1
@@ -140,3 +140,46 @@ Describe 'Initialize-Database.when a database was initialized with an early vers
         Assert-Column -DataType 'datetime2' @assertColumnParams
     }
 }
+
+Describe 'Initialize-Database.when a schema.ps1 file exists' {
+    BeforeEach { Init }
+    AfterEach { Reset }
+    It 'should initialize databases with schema.ps1 file' {
+        $schemaFileContents = @'
+        function Push-Migration
+        {
+            Add-Table -Name 'Replicated' -Column {
+                int 'ID' -Identity
+            }
+            Add-Table -Name 'NotReplicated' -Column {
+                int 'ID' -Identity -NotForReplication
+            }
+        }
+        function Pop-Migration
+        {
+            Remove-Table 'Replicated'
+            Remove-Table 'NotReplicated'
+        }
+'@
+
+        $config = Get-RivetConfig -Path $RTConfigFilePath -Database $RTDatabaseName
+        $migrationsDirectory = Join-Path -Path $config.DatabasesRoot -ChildPath "$($RTDatabaseName)\Migrations"
+        $schemaFilePath = Join-Path -Path $migrationsDirectory -ChildPath 'schema.ps1'
+        Set-Content -Path $schemaFilePath -Value $schemaFileContents
+
+        Invoke-RTRivet -Push
+        Assert-Table 'Replicated'
+        Assert-Table 'NotReplicated'
+
+        # Making sure that tables created from the schema.ps1 script still exists after popping
+        Invoke-RTRivet -Pop
+        Assert-Table 'Replicated'
+        Assert-Table 'NotReplicated'
+
+        # # Now drop the tables to avoid error from Clear-TestDatbase
+        $query = 'DROP TABLE Replicated'
+        Invoke-RivetTestQuery -Query $query -DatabaseName 'RivetTest'
+        $query = 'DROP TABLE NotReplicated'
+        Invoke-RivetTestQuery -Query $query -DatabaseName 'RivetTest'
+    }
+}

--- a/Test/Invoke-Rivet.Tests.ps1
+++ b/Test/Invoke-Rivet.Tests.ps1
@@ -121,7 +121,7 @@ Describe 'Invoke-Rivet' {
 '@ | New-TestMigration -Name 'HasReservedID' -Database $RTDatabaseName    
     
         $file | Should -Not -BeNullOrEmpty
-        $file = Rename-Item -Path $file -NewName ('00999999999999_HasReservedID.ps1') -PassThru
+        $file = Rename-Item -Path $file -NewName ('00010100999999_HasReservedID.ps1') -PassThru
     
         Invoke-RTRivet -Push -ErrorAction SilentlyContinue
         $Global:Error.Count | Should -BeGreaterThan 0
@@ -129,7 +129,7 @@ Describe 'Invoke-Rivet' {
         (Test-Schema -Name 'fubar') | Should -BeFalse
     
         $Global:Error.Clear()
-        Rename-Item -Path $file -NewName ('01000000000000_HasReservedID.ps1')
+        Rename-Item -Path $file -NewName ('00010101000000_HasReservedID.ps1')
         Invoke-RTRivet -Push 
         $Global:Error.Count | Should -Be 0
         Assert-Schema -Name 'fubar'

--- a/Test/RivetTest/Functions/Clear-TestDatabase.ps1
+++ b/Test/RivetTest/Functions/Clear-TestDatabase.ps1
@@ -22,7 +22,7 @@ function Clear-TestDatabase
 
     if( Test-Database -Name $Name )
     {
-        $query = "select * from [$($Name)].[rivet].[Migrations] where ID > 1000000000 order by ID"
+        $query = "select * from [$($Name)].[rivet].[Migrations] where ID > 10101000000 order by ID"
         [object[]]$migrations = Invoke-RivetTestQuery -Query $query -DatabaseName $Name
         if( ($migrations | Measure-Object).Count )
         {

--- a/Test/RivetTest/Functions/Get-ActivityInfo.ps1
+++ b/Test/RivetTest/Functions/Get-ActivityInfo.ps1
@@ -11,7 +11,7 @@ function Get-ActivityInfo
     
     Set-StrictMode -Version Latest
 
-    $query = 'select * from {0}.Activity where MigrationID >= 01000000000000' -f $RTRivetSchemaName
+    $query = 'select * from {0}.Activity where MigrationID >= 00010101000000' -f $RTRivetSchemaName
     if( $Name )
     {
         $query = '{0} and name = ''{1}''' -f $query,$Name

--- a/Test/RivetTest/Functions/Get-MigrationInfo.ps1
+++ b/Test/RivetTest/Functions/Get-MigrationInfo.ps1
@@ -14,7 +14,7 @@ function Get-MigrationInfo
     Set-StrictMode -Version Latest
 
     # Exclude Rivet's internal migrations.
-    $query = 'select * from {0}.Migrations where ID >= 01000000000000' -f $RTRivetSchemaName
+    $query = 'select * from {0}.Migrations where ID >= 00010101000000' -f $RTRivetSchemaName
     if( $Name )
     {
         $query = '{0} and  name = ''{1}''' -f $query,$Name

--- a/Test/RivetTest/Functions/Measure-Migration.ps1
+++ b/Test/RivetTest/Functions/Measure-Migration.ps1
@@ -3,6 +3,6 @@ function Measure-Migration
 {
     Set-StrictMode -Version Latest
     
-    $query = 'select count(*) from {0}.Migrations where ID >= 01000000000000' -f $RTRivetSchemaName
+    $query = 'select count(*) from {0}.Migrations where ID >= 00010101000000' -f $RTRivetSchemaName
     Invoke-RivetTestQuery -Query $query -AsScalar
 }


### PR DESCRIPTION
* The reserved migration IDs threshold has been changed from anything below `10000000000000` to anything below
`00010101000000`.
* `Initialize-Database` will now include the `schema.ps1` file from the database's migration directory if it exists.