### PR TITLE
Feature/initialize database with schema file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 
+# 0.17.0
+
+## Changes 
+
+* When initializing a database, Rivet now runs the migrations found in the schema.ps1 file, which contains the baseline
+database schema upon which all migrations should be applied. You can use the `Checkpoint-Migration` function to create
+a baseline `schema.ps1` file for your database(s).
+
+
 # 0.16.0
 
 * Updated `Checkpoint-Migration` function:

--- a/Rivet/Functions/Convert-FileInfoToMigration.ps1
+++ b/Rivet/Functions/Convert-FileInfoToMigration.ps1
@@ -105,16 +105,7 @@ Push-Migration function not found. All migrations are required to have a Push-Mi
                 Push-Migration | Add-Operation -OperationsList $m.PushOperations
                 if( $m.PushOperations.Count -eq 0 )
                 {
-                    throw (@'
-Push-Migration function is empty and contains no operations. Maybe you''d like to create a table? Here's some sample code to get you started:
-
-    function Push-Migration
-    {
-        Add-Table 'LetsCreateATable' {
-            int 'ID' -NotNull
-        }
-    }
-'@)
+                    return
                 }
             
                 if( -not (Test-Path -Path 'function:Pop-Migration') )
@@ -133,14 +124,7 @@ Pop-Migration function not found. All migrations are required to have a Pop-Migr
                 Pop-Migration | Add-Operation -OperationsList $m.PopOperations
                 if( $m.PopOperations.Count -eq 0 )
                 {
-                    throw (@'
-Pop-Migration function is empty and contains no operations. Maybe you''d like to drop a table? Here's some sample code to get you started:
-
-    function Pop-Migration
-    {
-        Remove-Table 'LetsCreateATable'
-    }
-'@)
+                    return
                 }
 
                 $afterMigrationLoadParameter = @{ Migration = $m }

--- a/Rivet/Functions/Get-MigrationFile.ps1
+++ b/Rivet/Functions/Get-MigrationFile.ps1
@@ -64,14 +64,21 @@ function Get-MigrationFile
             }
         } | 
         ForEach-Object {
-            if( $_.BaseName -notmatch '^(\d{14})_(.+)' )
+            if( $_.BaseName -eq 'schema' )
+            {
+                $id = $script:schemaMigrationId # midnight on year 1, month 0, day 0.
+                $name = $_.BaseName
+            }
+            elseif( $_.BaseName -notmatch '^(\d{14})_(.+)' )
             {
                 Write-Error ('Migration {0} has invalid name.  Must be of the form `YYYYmmddhhMMss_MigrationName.ps1' -f $_.FullName)
                 return
             }
-        
-            $id = [int64]$matches[1]
-            $name = $matches[2]
+            else
+            {
+                $id = [int64]$matches[1]
+                $name = $matches[2]
+            }
         
             $_ | 
                 Add-Member -MemberType NoteProperty -Name 'MigrationID' -Value $id -PassThru |

--- a/Rivet/Functions/Initialize-Database.ps1
+++ b/Rivet/Functions/Initialize-Database.ps1
@@ -13,9 +13,21 @@ function Initialize-Database
     )
 
     Set-StrictMode -Version 'Latest'
+    Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
 
     $who = ('{0}\{1}' -f $env:USERDOMAIN,$env:USERNAME);
-    $migrationsPath = Join-Path -Path $rivetModuleRoot -ChildPath 'Migrations'
+    $migrationPaths = [System.Collections.ArrayList]::new()
+    $rivetMigrationsPath = Join-Path -Path $rivetModuleRoot -ChildPath 'Migrations'
+    $migrationPaths.Add($rivetMigrationsPath) | Out-Null
     Write-Debug -Message ('# {0}.{1}' -f $Connection.DataSource,$Connection.Database)
-    Update-Database -Path $migrationsPath -RivetSchema -Configuration $Configuration
+
+    # Add schema.ps1 file from database's migration directory if it exists
+    $databaseItem = $Configuration.Databases | Where-Object {$_.Name -eq $Connection.Database}
+    $schemaFilePath = Join-Path -Path $databaseItem.MigrationsRoot -ChildPath 'schema.ps1'
+    if( (Test-Path -Path $schemaFilePath) )
+    {
+        $migrationPaths.Add($schemaFilePath) | Out-Null
+    }
+
+    Update-Database -Path $migrationPaths -RivetSchema -Configuration $Configuration
 }

--- a/Rivet/Functions/New-Migration.ps1
+++ b/Rivet/Functions/New-Migration.ps1
@@ -20,6 +20,9 @@ function New-Migration
         $Path
     )
 
+    Set-StrictMode -Version 'Latest'
+    Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+
     foreach( $nameItem in $Name )
     {
         $id = $null
@@ -37,6 +40,15 @@ function New-Migration
         $migrationPath = Join-Path -Path $Path -ChildPath $filename
         $migrationPath = [IO.Path]::GetFullPath( $migrationPath )
         New-Item -Path $migrationPath -Force -ItemType File
+
+        $schemaPs1Path = Join-Path -Path $Path -ChildPath $script:schemaFileName
+        if (-not (Test-Path -Path $schemaPs1Path))
+        {
+            $script:defaultSchemaPs1Content | Set-Content -Path $schemaPs1Path
+            $msg = "Rivet created ""$($schemaPs1Path | Resolve-Path -Relative)"", a file where Rivet to stores the " +
+                   'database''s baseline schema. PLEASE CHECK THIS FILE INTO SOURCE CONTROL.'
+            Write-Warning $msg
+        }
 
         $template = @"
 <#

--- a/Rivet/Functions/New-Migration.ps1
+++ b/Rivet/Functions/New-Migration.ps1
@@ -45,7 +45,7 @@ function New-Migration
         if (-not (Test-Path -Path $schemaPs1Path))
         {
             $script:defaultSchemaPs1Content | Set-Content -Path $schemaPs1Path
-            $msg = "Rivet created ""$($schemaPs1Path | Resolve-Path -Relative)"", a file where Rivet to stores the " +
+            $msg = "Rivet created ""$($schemaPs1Path | Resolve-Path -Relative)"", a file where Rivet stores the " +
                    'database''s baseline schema. PLEASE CHECK THIS FILE INTO SOURCE CONTROL.'
             Write-Warning $msg
         }

--- a/Rivet/Functions/Update-Database.ps1
+++ b/Rivet/Functions/Update-Database.ps1
@@ -66,6 +66,7 @@ function Update-Database
     )
 
     Set-StrictMode -Version 'Latest'
+    Use-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
 
     function ConvertTo-RelativeTime
     {
@@ -147,9 +148,9 @@ function Update-Database
                 return $true
             }
 
-            if( [int64]$_.MigrationID -lt 1000000000000 )
+            if( [int64]$_.MigrationID -lt $script:firstMigrationId )
             {
-                Write-Error ('Migration "{0}" has an invalid ID. IDs lower than 01000000000000 are reserved for internal use.' -f $_.FullName) -ErrorAction Stop
+                Write-Error "Migration '$($_.FullName)' has an invalid ID. IDs lower than $($script:firstMigrationId) are reserved for internal use." -ErrorAction Stop
                 return $false
             }
             return $true

--- a/Rivet/Rivet.psd1
+++ b/Rivet/Rivet.psd1
@@ -11,7 +11,7 @@
     RootModule = 'Rivet.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.16.0'
+    ModuleVersion = '0.17.0'
 
     # ID used to uniquely identify this module
     GUID = '8af34b47-259b-4630-a945-75d38c33b94d'

--- a/Rivet/Rivet.psm1
+++ b/Rivet/Rivet.psm1
@@ -7,6 +7,21 @@ $RivetMigrationsTableFullName = "[$($RivetSchemaName)].[$($RivetMigrationsTableN
 $RivetActivityTableName = 'Activity'
 $rivetModuleRoot = $PSScriptRoot
 $script:firstMigrationId = [Int64]'00010101000000' # 1/1/1 00:00:00
+$script:schemaMigrationId = [Int64]'00010000000000' # Special ID for schema.ps1, 1/0/0 00:00:00.
+$script:schemaFileName = 'schema.ps1'
+$script:defaultSchemaPs1Content = @"
+# DO NOT MODIFY THIS FILE. The current database schema is saved to this file as a Rivet migration when you checkpoint
+# your database. Any changes manually made to this file will eventually be lost. This file should be checked into source
+# control alongside normal database migrations.
+
+function Push-Migration
+{
+}
+
+function Pop-Migration
+{
+}
+"@
 
 $timer = New-Object 'Diagnostics.Stopwatch'
 $timerForWrites = New-Object 'Diagnostics.Stopwatch'

--- a/Rivet/Rivet.psm1
+++ b/Rivet/Rivet.psm1
@@ -6,7 +6,7 @@ $RivetMigrationsTableName = 'Migrations'
 $RivetMigrationsTableFullName = "[$($RivetSchemaName)].[$($RivetMigrationsTableName)]"
 $RivetActivityTableName = 'Activity'
 $rivetModuleRoot = $PSScriptRoot
-[Int64] $script:firstMigrationId = 00010101000000
+$script:firstMigrationId = [Int64]'00010101000000' # 1/1/1 00:00:00
 
 $timer = New-Object 'Diagnostics.Stopwatch'
 $timerForWrites = New-Object 'Diagnostics.Stopwatch'

--- a/Test/Get-Migration.Tests.ps1
+++ b/Test/Get-Migration.Tests.ps1
@@ -140,11 +140,11 @@ Describe 'Get-Migration' {
         $m | Should -BeOfType ([Rivet.Migration])
     }
     
-    It 'should reject migration with empty push' {
+    It 'should ignore migration with empty push' {
         $m = @'
     function Push-Migration
     {
-        # I'm empty. That is bad!
+        # I'm empty.
     }
     
     function Pop-Migration
@@ -157,8 +157,7 @@ Describe 'Get-Migration' {
         {
             $result = Get-Migration -ConfigFilePath $RTConfigFilePath -ErrorAction SilentlyContinue
             $result | Should -BeNullOrEmpty
-            $Global:Error.Count | Should -BeGreaterThan 0
-            $Global:Error[0] | Should -Match 'Push-Migration.*empty'
+            $Global:Error | Should -BeNullOrEmpty
         }
         finally
         {
@@ -166,7 +165,7 @@ Describe 'Get-Migration' {
         }
     }
     
-    It 'should reject migration with empty pop' {
+    It 'should ignore migration with empty pop' {
         $m = @'
     function Push-Migration
     {
@@ -175,7 +174,7 @@ Describe 'Get-Migration' {
     
     function Pop-Migration
     {
-        # I'm empty. That is bad!
+        # I'm empty.
     }
 '@ | New-TestMigration -Name 'EmptyPop'
     
@@ -183,8 +182,7 @@ Describe 'Get-Migration' {
         {
             $result = Get-Migration -ConfigFilePath $RTConfigFilePath -ErrorAction SilentlyContinue
             $result | Should -BeNullOrEmpty
-            $Global:Error.Count | Should -BeGreaterThan 0
-            $Global:Error[0] | Should -Match 'Pop-Migration.*empty'
+            $Global:Error | Should -BeNullOrEmpty
         }
         finally
         {

--- a/Test/Invoke-Rivet.Tests.ps1
+++ b/Test/Invoke-Rivet.Tests.ps1
@@ -121,7 +121,7 @@ Describe 'Invoke-Rivet' {
 '@ | New-TestMigration -Name 'HasReservedID' -Database $RTDatabaseName    
     
         $file | Should -Not -BeNullOrEmpty
-        $file = Rename-Item -Path $file -NewName ('00999999999999_HasReservedID.ps1') -PassThru
+        $file = Rename-Item -Path $file -NewName ('00010100999999_HasReservedID.ps1') -PassThru
     
         Invoke-RTRivet -Push -ErrorAction SilentlyContinue
         $Global:Error.Count | Should -BeGreaterThan 0
@@ -129,7 +129,7 @@ Describe 'Invoke-Rivet' {
         (Test-Schema -Name 'fubar') | Should -BeFalse
     
         $Global:Error.Clear()
-        Rename-Item -Path $file -NewName ('01000000000000_HasReservedID.ps1')
+        Rename-Item -Path $file -NewName ('00010101000000_HasReservedID.ps1')
         Invoke-RTRivet -Push 
         $Global:Error.Count | Should -Be 0
         Assert-Schema -Name 'fubar'

--- a/Test/RivetTest/Functions/Clear-TestDatabase.ps1
+++ b/Test/RivetTest/Functions/Clear-TestDatabase.ps1
@@ -22,7 +22,7 @@ function Clear-TestDatabase
 
     if( Test-Database -Name $Name )
     {
-        $query = "select * from [$($Name)].[rivet].[Migrations] where ID > 1000000000 order by ID"
+        $query = "select * from [$($Name)].[rivet].[Migrations] where ID > $($script:firstMigrationId) order by ID"
         [object[]]$migrations = Invoke-RivetTestQuery -Query $query -DatabaseName $Name
         if( ($migrations | Measure-Object).Count )
         {

--- a/Test/RivetTest/Functions/Get-ActivityInfo.ps1
+++ b/Test/RivetTest/Functions/Get-ActivityInfo.ps1
@@ -11,7 +11,7 @@ function Get-ActivityInfo
     
     Set-StrictMode -Version Latest
 
-    $query = 'select * from {0}.Activity where MigrationID >= 01000000000000' -f $RTRivetSchemaName
+    $query = "select * from $($RTRivetSchemaName).Activity where MigrationID >= $($script:firstMigrationId)"
     if( $Name )
     {
         $query = '{0} and name = ''{1}''' -f $query,$Name

--- a/Test/RivetTest/Functions/Get-MigrationInfo.ps1
+++ b/Test/RivetTest/Functions/Get-MigrationInfo.ps1
@@ -14,7 +14,7 @@ function Get-MigrationInfo
     Set-StrictMode -Version Latest
 
     # Exclude Rivet's internal migrations.
-    $query = 'select * from {0}.Migrations where ID >= 01000000000000' -f $RTRivetSchemaName
+    $query = "select * from $($RTRivetSchemaName).Migrations where ID >= $($script:firstMigrationId)"
     if( $Name )
     {
         $query = '{0} and  name = ''{1}''' -f $query,$Name

--- a/Test/RivetTest/Functions/Measure-Migration.ps1
+++ b/Test/RivetTest/Functions/Measure-Migration.ps1
@@ -3,6 +3,6 @@ function Measure-Migration
 {
     Set-StrictMode -Version Latest
     
-    $query = 'select count(*) from {0}.Migrations where ID >= 01000000000000' -f $RTRivetSchemaName
+    $query = "select count(*) from $($RTRivetSchemaName).Migrations where ID >= $($script:firstMigrationId)"
     Invoke-RivetTestQuery -Query $query -AsScalar
 }

--- a/Test/RivetTest/RivetTest.psm1
+++ b/Test/RivetTest/RivetTest.psm1
@@ -24,6 +24,7 @@ if( -not $RivetRoot )
 $RTRivetSchemaName = 'rivet'
 $RTDatabaseName = 'RivetTest'
 $RTDatabase2Name = 'RivetTest2'
+$script:firstMigrationId = [Int64]'00010101000000' # 1/1/1 00:00:00
 
 $serverFileDirs = @( 
                         (Join-Path -Path $PSScriptRoot -ChildPath '..' -Resolve),


### PR DESCRIPTION
* When initializing a database, Rivet now runs the migrations found in the schema.ps1 file, which contains the baseline
database schema upon which all migrations should be applied. You can use the `Checkpoint-Migration` function to create
a baseline `schema.ps1` file for your database(s).