### PR TITLE
Implement Command Timeout on Rivet Operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 
+# 0.19.1
+
+* Fixed: Rivet doesn't use the CommandTimeout property in rivet.json configuration file.
+
+
 # 0.19.0
 
 * `Export-Migration` will now allow references to objects in databases that have been applied before it.

--- a/Rivet/Functions/Convert-FileInfoToMigration.ps1
+++ b/Rivet/Functions/Convert-FileInfoToMigration.ps1
@@ -58,6 +58,9 @@ function Convert-FileInfoToMigration
                     continue
                 }
 
+                # Set CommandTimeout on operation to value from Rivet configuration.
+                $operationItem.CommandTimeout = $Configuration.CommandTimeout
+                
                 $pluginParameter = @{ Migration = $m ; Operation = $_ }
 
                 [Rivet.Operations.Operation[]]$operations = & {

--- a/Rivet/Rivet.psd1
+++ b/Rivet/Rivet.psd1
@@ -11,7 +11,7 @@
     RootModule = 'Rivet.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.19.0'
+    ModuleVersion = '0.19.1'
 
     # ID used to uniquely identify this module
     GUID = '8af34b47-259b-4630-a945-75d38c33b94d'

--- a/Test/Get-Migration.Tests.ps1
+++ b/Test/Get-Migration.Tests.ps1
@@ -338,6 +338,45 @@ Describe 'Get-Migration' {
         'ShouldGetAMigrationByBaseNameWithWildcard' | Should -Be $result.Name
         $m.BaseName | Should -Be $result.FullName
     }
+
+    It 'should set timeout duration to default 30 seconds on Rivet operations when CommandTimeout isn''t specified in the Rivet configuration' {
+        @'
+        function Push-Migration
+        {
+            Invoke-Ddl 'select 1'
+        }
+        function Pop-Migration
+        {
+            Invoke-Ddl 'select 1'
+        }
+'@ | New-TestMigration -Name 'SetCommandTimeout'
+        
+        $m = Get-Migration -ConfigFilePath $RTConfigFilePath
+        $Global:Error.Count | Should -Be 0
+        $m | Should -BeOfType ([Rivet.Migration])
+        $m.PopOperations[0].CommandTimeout | Should -Be 30
+        $m.PushOperations[0].CommandTimeout | Should -Be 30
+    }
+    
+    It 'should set timeout duration on Rivet operations when CommandTimeout is specified in the Rivet configuration' {
+        Start-RivetTest -CommandTimeout 60
+        @'
+        function Push-Migration
+        {
+            Invoke-Ddl 'select 1'
+        }
+        function Pop-Migration
+        {
+            Invoke-Ddl 'select 1'
+        }
+'@ | New-TestMigration -Name 'SetCommandTimeout'
+        
+        $m = Get-Migration -ConfigFilePath $RTConfigFilePath
+        $Global:Error.Count | Should -Be 0
+        $m | Should -BeOfType ([Rivet.Migration])
+        $m.PopOperations[0].CommandTimeout | Should -Be 60
+        $m.PushOperations[0].CommandTimeout | Should -Be 60
+    }
 }
 
 Describe 'Get-Migration.when excluding migrations' {

--- a/Test/RivetTest/Functions/Start-RivetTest.ps1
+++ b/Test/RivetTest/Functions/Start-RivetTest.ps1
@@ -11,7 +11,9 @@ function Start-RivetTest
         [Alias('DatabaseName')]
         [String[]] $PhysicalDatabase = $RTDatabaseName,
 
-        [String[]] $ConfigurationDatabase
+        [String[]] $ConfigurationDatabase,
+
+        [int] $CommandTimeout = 30
     )
     
     Set-StrictMode -Version Latest
@@ -71,7 +73,8 @@ function Start-RivetTest
     $content = @"
 {
     SqlServerName: '$($RTServer.Replace('\', '\\'))',
-    DatabasesRoot: '$($RTDatabasesRoot.Replace('\','\\'))'
+    DatabasesRoot: '$($RTDatabasesRoot.Replace('\','\\'))',
+    CommandTimeout: $($CommandTimeout)
 "@
 
     if( $ConfigurationDatabase )


### PR DESCRIPTION
* Fixed: Rivet doesn't use the CommandTimeout property in rivet.json configuration file.