### PR TITLE
Fixed: Rivet creates invalid SQL when merging a migration that update…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,16 @@
 
 # Rivet Changelog
 
+## 0.23.1
+
+### Fixed
+
+* Fixed: Rivet generates invalid SQL when merging a migration that contains an update to a column and adding a default
+constraint to that same column.
+
 ## 0.23.0
+
+> Released 10 Sep 2024
 
 ### Changed
 

--- a/Rivet/Functions/Merge-Migration.ps1
+++ b/Rivet/Functions/Merge-Migration.ps1
@@ -5,23 +5,32 @@ function Merge-Migration
     Creates a cumulative set of operations from migration scripts.
 
     .DESCRIPTION
-    The `Merge-Migration` functions creates a cumulative set of migrations from migration scripts. If there are multiple operations across one or more migration scripts that touch the same database object, those changes are combined into one operation. For example, if you create a table in one migration, add a column in another migrations, then remove a column in a third migration, this function will output an operation that represents the final state for the object: a create table operation that includes the added column and doesn't include the removed column. In environments where tables are replicated, it is more efficient to modify objects once and have that change replicated once, than to have the same object modified multiple times and replicated multiple times.
+    The `Merge-Migration` functions creates a cumulative set of migrations from migration scripts. If there are multiple
+    operations across one or more migration scripts that touch the same database object, those changes are combined into
+    one operation. For example, if you create a table in one migration, add a column in another migrations, then remove
+    a column in a third migration, this function will output an operation that represents the final state for the
+    object: a create table operation that includes the added column and doesn't include the removed column. In
+    environments where tables are replicated, it is more efficient to modify objects once and have that change
+    replicated once, than to have the same object modified multiple times and replicated multiple times.
 
-    This function returns `Rivet.Migration` objects. Each object will have zero or more operations in its `PushOperations` property. If there are zero operations, it means the original operation was consolidated into another migration. Each operation has `Source` member on it, which is a list of all the migrations that contributed to that operation. 
+    This function returns `Rivet.Migration` objects. Each object will have zero or more operations in its
+    `PushOperations` property. If there are zero operations, it means the original operation was consolidated into
+    another migration. Each operation has `Source` member on it, which is a list of all the migrations that contributed
+    to that operation.
 
     .OUTPUTS
     Rivet.Migration
 
     .EXAMPLE
-    Get-Migration | Merge-Migration 
+    Get-Migration | Merge-Migration
 
     Demonstrates how to run `Merge-Migration`. It is always used in conjunction with `Get-Migration`.
     #>
     [CmdletBinding()]
     [OutputType([Rivet.Migration])]
     param(
-        [Parameter(ValueFromPipeline)]
         # The path to the rivet.json file to use. By default, it will look in the current directory.
+        [Parameter(ValueFromPipeline)]
         [Rivet.Migration[]]$Migration
     )
 
@@ -31,7 +40,9 @@ function Merge-Migration
 
         # Collect all the migrations. We can't merge anything until we get to the end.
         [Collections.ArrayList]$migrations = [Collections.ArrayList]::New()
-        [Collections.Generic.List[Rivet.Operations.Operation]]$allOperations = [Collections.Generic.List[Rivet.Operations.Operation]]::New()
+
+        [Collections.Generic.List[Rivet.Operations.Operation]]$allOperations =
+            [Collections.Generic.List[Rivet.Operations.Operation]]::New()
     }
 
     process
@@ -61,7 +72,7 @@ function Merge-Migration
                 $operation = $migrationItem.PushOperations[$idx]
                 if( $operation.Disabled )
                 {
-                    $migrationItem.PushOperations.RemoveAt($idx)    
+                    $migrationItem.PushOperations.RemoveAt($idx)
                 }
             }
             $migrationItem | Write-Output

--- a/Rivet/Rivet.psd1
+++ b/Rivet/Rivet.psd1
@@ -11,7 +11,7 @@
     RootModule = 'Rivet.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.23.0'
+    ModuleVersion = '0.23.1'
 
     # ID used to uniquely identify this module
     GUID = '8af34b47-259b-4630-a945-75d38c33b94d'

--- a/Source/Operations/UpdateTableOperation.cs
+++ b/Source/Operations/UpdateTableOperation.cs
@@ -42,20 +42,6 @@ namespace Rivet.Operations
 
 			switch (operation)
 			{
-				case AddDefaultConstraintOperation otherAsAddDefaultConstraintOp when !otherAsAddDefaultConstraintOp.WithValues:
-				{
-					var column = FindColumn(otherAsAddDefaultConstraintOp.ColumnName);
-					if (column != null)
-					{
-						column.DefaultExpression = otherAsAddDefaultConstraintOp.Expression;
-						column.DefaultConstraintName = otherAsAddDefaultConstraintOp.Name;
-						otherAsAddDefaultConstraintOp.Disabled = true;
-						return MergeResult.Continue;
-					}
-
-					break;
-				}
-
 				case AddRowGuidColOperation otherAsAddRowGuidColOp:
 				{
 					var column = FindColumn(otherAsAddRowGuidColOp.ColumnName);

--- a/Source/Test/Operations/UpdateTableOperationTestFixture.cs
+++ b/Source/Test/Operations/UpdateTableOperationTestFixture.cs
@@ -36,7 +36,7 @@ namespace Rivet.Test.Operations
 			var op = new UpdateTableOperation(SchemaName, Name, addColumnList, null, null);
 
 			var expectedQuery =
-				$"alter table [schemaName].[name] add [name] varchar(50) not null constraint [{DefaultConstraintName}] default ''{Environment.NewLine}" + 
+				$"alter table [schemaName].[name] add [name] varchar(50) not null constraint [{DefaultConstraintName}] default ''{Environment.NewLine}" +
 				"alter table [schemaName].[name] add [int column] int identity not null";
 
 			Assert.AreEqual(expectedQuery, op.ToQuery());
@@ -48,7 +48,7 @@ namespace Rivet.Test.Operations
 			var op = new UpdateTableOperation(SchemaName, Name, null, updateColumnList, null);
 
 			var expectedQuery =
-				$"alter table [schemaName].[name] alter column [int column] int identity not null{Environment.NewLine}" + 
+				$"alter table [schemaName].[name] alter column [int column] int identity not null{Environment.NewLine}" +
 				$"alter table [schemaName].[name] alter column [name] varchar(50) not null constraint [{DefaultConstraintName}] default ''";
 
 			Assert.AreEqual(expectedQuery, op.ToQuery());
@@ -59,7 +59,7 @@ namespace Rivet.Test.Operations
 		{
 			var op = new UpdateTableOperation(SchemaName, Name, null, null, removeColumnList);
 
-			var expectedQuery = 
+			var expectedQuery =
 				string.Format("alter table [schemaName].[name] drop column [column 3]{0}alter table [schemaName].[name] drop column [column 4]", Environment.NewLine);
 
 			Assert.AreEqual(expectedQuery, op.ToQuery());
@@ -73,8 +73,8 @@ namespace Rivet.Test.Operations
 			var expectedQuery =
 				$"alter table [schemaName].[name] add [name] varchar(50) not null constraint [{DefaultConstraintName}] default ''{Environment.NewLine}" +
 				$"alter table [schemaName].[name] add [int column] int identity not null{Environment.NewLine}" +
-				$"alter table [schemaName].[name] alter column [int column] int identity not null{Environment.NewLine}" + 
-				$"alter table [schemaName].[name] alter column [name] varchar(50) not null constraint [{DefaultConstraintName}] default ''{Environment.NewLine}" + 
+				$"alter table [schemaName].[name] alter column [int column] int identity not null{Environment.NewLine}" +
+				$"alter table [schemaName].[name] alter column [name] varchar(50) not null constraint [{DefaultConstraintName}] default ''{Environment.NewLine}" +
 				$"alter table [schemaName].[name] drop column [column 3]{Environment.NewLine}alter table [schemaName].[name] drop column [column 4]";
 
 			Assert.AreEqual(expectedQuery, op.ToQuery());
@@ -113,7 +113,7 @@ namespace Rivet.Test.Operations
 		}
 
 		[Test]
-		public void ShouldAddDefaultExpressionAndConstraintNameToAddedColumnsAndDisableAddDefaultConstraint()
+		public void ShouldNotAddDefaultExpressionAndConstraintNameToAddedColumnsAndDisableAddDefaultConstraint()
 		{
 			var columns = new[]
 			{
@@ -125,15 +125,15 @@ namespace Rivet.Test.Operations
 				new AddDefaultConstraintOperation("SCHEMA", "TABLE", "NAME", "COLUMN2", "expression", false);
 			op.Merge(addDefaultConstraintOp);
 			Assert.That(op.Disabled, Is.False);
-			Assert.That(addDefaultConstraintOp.Disabled, Is.True);
+			Assert.That(addDefaultConstraintOp.Disabled, Is.False);
 			Assert.That(op.AddColumns[0].DefaultExpression, Is.Null);
 			Assert.That(op.AddColumns[0].DefaultConstraintName, Is.Null);
-			Assert.That(op.AddColumns[1].DefaultExpression, Is.EqualTo("expression"));
-			Assert.That(op.AddColumns[1].DefaultConstraintName, Is.EqualTo("NAME"));
+			Assert.That(op.AddColumns[1].DefaultExpression, Is.Null);
+			Assert.That(op.AddColumns[1].DefaultConstraintName, Is.Null);
 		}
 
 		[Test]
-		public void ShouldAddDefaultExpressionToUpdatedColumnsAndDisableAddDefaultConstraint()
+		public void ShouldNotAddDefaultExpressionToUpdatedColumnsAndDisableAddDefaultConstraint()
 		{
 			var columns = new[]
 			{
@@ -145,11 +145,11 @@ namespace Rivet.Test.Operations
 				new AddDefaultConstraintOperation("SCHEMA", "TABLE", "NAME", "COLUMN2", "expression", false);
 			op.Merge(addDefaultConstraintOp);
 			Assert.That(op.Disabled, Is.False);
-			Assert.That(addDefaultConstraintOp.Disabled, Is.True);
+			Assert.That(addDefaultConstraintOp.Disabled, Is.False);
 			Assert.That(op.UpdateColumns[0].DefaultExpression, Is.Null);
 			Assert.That(op.UpdateColumns[0].DefaultConstraintName, Is.Null);
-			Assert.That(op.UpdateColumns[1].DefaultExpression, Is.EqualTo("expression"));
-			Assert.That(op.UpdateColumns[1].DefaultConstraintName, Is.EqualTo("NAME"));
+			Assert.That(op.UpdateColumns[1].DefaultExpression, Is.Null);
+			Assert.That(op.UpdateColumns[1].DefaultConstraintName, Is.Null);
 		}
 
 		[Test]
@@ -395,7 +395,7 @@ namespace Rivet.Test.Operations
 				new[] { Column.Int("column1", new Identity(), null), Column.Bit("column2", Nullable.Null, null, null, null) },
 				new[] { Column.Int("column3", new Identity(), null), Column.Bit("column4", Nullable.Null, null, null, null) },
 				new[] { "column6", "column7" });
-			var otherUpdateOp = new UpdateTableOperation("SCHEMA", "NAME", 
+			var otherUpdateOp = new UpdateTableOperation("SCHEMA", "NAME",
 				new [] { Column.Int("COLUMN7", Nullable.Null, null, null, null), Column.Bit("column8", Nullable.NotNull, null, null, null) },
 				new [] { Column.BigInt("COLUMN1", new Identity(), null), Column.Bit("column9", Nullable.Null, null, null, null)},
 				new [] { "COLUMN2", "COLUMN4", "column10" });

--- a/Test/Merge-Migration.Tests.ps1
+++ b/Test/Merge-Migration.Tests.ps1
@@ -767,4 +767,25 @@ as
         $columns[1].Name | Should -Be 'errorId'
         $result[1].PushOperations | Should -HaveCount 0
     }
+
+    # bug
+    It 'merges not null and default constraint operations into separate queries' {
+        $result = Invoke-MergeMigration {
+            New-MigrationObject 'two' {
+                Update-Table -Name 'table1' -UpdateColumn {
+                    bit 'TestColumn' -NotNull
+                }
+
+                Add-DefaultConstraint -TableName 'table1' `
+                                      -ColumnName 'TestColumn' `
+                                      -Name 'DF_table1_TestColumn' `
+                                      -Expression 1
+            }
+        }
+
+        $result | Should -HaveCount 1
+        $pushes = $result[0].PushOperations
+        $pushes | Should -HaveCount 2
+
+    }
 }


### PR DESCRIPTION
…s a column and adds a default constraint to that same column.